### PR TITLE
feat: implement GET /entries/{id} endpoint

### DIFF
--- a/api/routers/journal_router.py
+++ b/api/routers/journal_router.py
@@ -66,7 +66,11 @@ async def get_entry(request: Request, entry_id: str, entry_service: EntryService
     
     Hint: Check the update_entry endpoint for similar patterns
     """
-    raise HTTPException(status_code=501, detail="Not implemented - complete this endpoint!")
+    entry = await entry_service.get_entry(entry_id)
+    if entry:
+        return entry
+    else:
+        raise HTTPException(status_code=404, detail="Entry not found")
 
 @router.patch("/entries/{entry_id}")
 async def update_entry(request: Request, entry_id: str, entry_update: dict):


### PR DESCRIPTION
## 📝 Description
Implements GET /entries/{entry_id} endpoint for retrieving single journal entries.

## ✅ Testing Done
- [x] Tested with valid entry ID via /docs
- [x] Tested with invalid entry ID (returns 404)
- [x] Verified response matches Entry model schema

## 📸 Screenshots
### Valid Entry Response
<img width="1278" height="507" alt="Screenshot From 2025-09-10 00-28-07" src="https://github.com/user-attachments/assets/4089c69e-720f-4024-a5b4-d6dd49d2606e" />

### Invalid Entry Response
<img width="1278" height="507" alt="Screenshot From 2025-09-10 00-28-25" src="https://github.com/user-attachments/assets/66810396-17ee-4f4a-ab03-6231550762df" />
 


