### PR TITLE
Implemented feature/get_single_entry

### DIFF
--- a/api/routers/journal_router.py
+++ b/api/routers/journal_router.py
@@ -64,7 +64,7 @@ async def get_entry(request: Request, entry_id: str, entry_service: EntryService
     result = await entry_service.get_entry(entry_id)
 
     if not result:
-        raise HTTPException(status_code=501, detail="Entry not found")
+        raise HTTPException(status_code=404, detail="Entry not found")
     
     return result
 


### PR DESCRIPTION
Completed the first task in the Learn to Cloud Programming Capstone by implementing the GET /entries/entry_id endpoint. This uses the `get_entry()` method from the EntryService class to retrieve a single entry based on corresponding entry_id (captured via the path operation). 

It stores that dictionary in the variable `result`. If result is empty (entry was not found), throw a 404 HTTP exception. If result is found, return the result as JSON.