### PR TITLE
feat: Implemented DELETE /entries/{entry_id} endpoint to remove a specific entry

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/va-h/devcontainers-features/uv": {
+      "version": "1.1.4",
+      "resolved": "ghcr.io/va-h/devcontainers-features/uv@sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1",
+      "integrity": "sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1"
+    }
+  }
+}

--- a/api/main.py
+++ b/api/main.py
@@ -1,14 +1,11 @@
+import logging
+
 from fastapi import FastAPI
 
 from api.routers.journal_router import router as journal_router
 
-# TODO (Task 1): Configure logging here.
-# Reference: https://docs.python.org/3/howto/logging.html
-# Steps:
-#   1. ``import logging`` at the top of this file.
-#   2. Call ``logging.basicConfig(level=logging.INFO, format="...")``.
-#   3. Log an INFO message on startup (e.g. "Journal API starting up").
-
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logging.info("Journal API starting up")
 app = FastAPI(
     title="Journal API",
     description="A simple journal API for tracking daily work, struggles, and intentions",

--- a/api/routers/journal_router.py
+++ b/api/routers/journal_router.py
@@ -46,26 +46,6 @@ async def get_all_entries(entry_service: EntryService = Depends(get_entry_servic
 
 @router.get("/entries/{entry_id}")
 async def get_entry(entry_id: str, entry_service: EntryService = Depends(get_entry_service)):
-    """
-    TODO: Implement this endpoint to return a single journal entry by ID
-
-    Steps to implement:
-    1. Use entry_service.get_entry(entry_id) to fetch the entry
-    2. If entry is None, raise HTTPException with status_code=404
-    3. Return the entry directly (not wrapped in a dict)
-
-    Example response (status 200):
-    {
-        "id": "uuid-string",
-        "work": "...",
-        "struggle": "...",
-        "intention": "...",
-        "created_at": "...",
-        "updated_at": "..."
-    }
-
-    Hint: Check the update_entry endpoint for similar patterns
-    """
     result = await entry_service.get_entry(entry_id)
     if result is None:
         raise HTTPException(status_code=404, detail="Entry not found 404 error")

--- a/api/routers/journal_router.py
+++ b/api/routers/journal_router.py
@@ -72,25 +72,15 @@ async def update_entry(
     return result
 
 
-# TODO: Implement DELETE /entries/{entry_id} endpoint to remove a specific entry
 # Return 404 if entry not found
 @router.delete("/entries/{entry_id}")
 async def delete_entry(entry_id: str, entry_service: EntryService = Depends(get_entry_service)):
-    """
-    TODO: Implement this endpoint to delete a specific journal entry
-
-    Steps to implement:
-    1. Use entry_service.get_entry(entry_id) to check if entry exists
-    2. If entry is None, raise HTTPException with status_code=404
-    3. Use entry_service.delete_entry(entry_id) to delete the entry
-    4. Return a success response (status 200)
-
-    Example response (status 200):
-    {"detail": "Entry deleted successfully"}
-
-    Hint: Look at how the update_entry endpoint checks for existence
-    """
-    raise HTTPException(status_code=501, detail="Not implemented - complete this endpoint!")
+    result = await entry_service.get_entry(entry_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Entry not found")
+    await entry_service.delete_entry(entry_id)
+    return {"detail": "{entry_id} entry was deleted"}
+    # raise HTTPException(status_code=501, detail="Not implemented - complete this endpoint!")
 
 
 @router.delete("/entries")

--- a/api/routers/journal_router.py
+++ b/api/routers/journal_router.py
@@ -66,7 +66,11 @@ async def get_entry(entry_id: str, entry_service: EntryService = Depends(get_ent
 
     Hint: Check the update_entry endpoint for similar patterns
     """
-    raise HTTPException(status_code=501, detail="Not implemented - complete this endpoint!")
+    result = await entry_service.get_entry(entry_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Entry not found 404 error")
+    return result
+    # raise HTTPException(status_code=501, detail="Not implemented - complete this endpoint!")
 
 
 @router.patch("/entries/{entry_id}")


### PR DESCRIPTION
## Background
Completed task 2b to delete a single entry and return a 404 error when the entry does not exist.

## Validation
The `uv run pytest tests/test_api.py::TestDeleteEntry` test passed and I confirmed the 404 error message was observed using incorrect entry IDs. 

### Before
<img width="734" height="432" alt="image" src="https://github.com/user-attachments/assets/6802eb6f-ff75-438a-b01c-cdb6911c05bc" />

### After
<img width="645" height="324" alt="image" src="https://github.com/user-attachments/assets/128b3312-317e-4569-b738-cfd43f40632e" />

### Example showing 404 error
<img width="1653" height="950" alt="image" src="https://github.com/user-attachments/assets/60f51d62-78d9-4484-96fc-66d70b8a8a2c" />
