### PR TITLE
fix(): Modified `update_entry` function to not look at values set to `None`

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/va-h/devcontainers-features/uv": {
+      "version": "1.1.4",
+      "resolved": "ghcr.io/va-h/devcontainers-features/uv@sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1",
+      "integrity": "sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1"
+    }
+  }
+}

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,5 +1,10 @@
 {
   "features": {
+    "ghcr.io/devcontainers/features/aws-cli:1": {
+      "version": "1.1.4",
+      "resolved": "ghcr.io/devcontainers/features/aws-cli@sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef",
+      "integrity": "sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef"
+    },
     "ghcr.io/va-h/devcontainers-features/uv": {
       "version": "1.1.4",
       "resolved": "ghcr.io/va-h/devcontainers-features/uv@sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,9 +5,8 @@
   "dockerComposeFile": ["./docker-compose.yml"],
   "features": {
 		"ghcr.io/va-h/devcontainers-features/uv": {},
-		// TODO: Add one of these cloud CLI tools based on your needs:
         // "ghcr.io/devcontainers/features/azure-cli:1": {},
-        // "ghcr.io/devcontainers/features/aws-cli:1": {},
+        "ghcr.io/devcontainers/features/aws-cli:1": {}
         // "ghcr.io/devcontainers/features/gcloud:1": {}
 	},
   

--- a/api/main.py
+++ b/api/main.py
@@ -1,14 +1,11 @@
+import logging
+
 from fastapi import FastAPI
 
 from api.routers.journal_router import router as journal_router
 
-# TODO (Task 1): Configure logging here.
-# Reference: https://docs.python.org/3/howto/logging.html
-# Steps:
-#   1. ``import logging`` at the top of this file.
-#   2. Call ``logging.basicConfig(level=logging.INFO, format="...")``.
-#   3. Log an INFO message on startup (e.g. "Journal API starting up").
-
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logging.info("Journal API starting up")
 app = FastAPI(
     title="Journal API",
     description="A simple journal API for tracking daily work, struggles, and intentions",

--- a/api/models/entry.py
+++ b/api/models/entry.py
@@ -1,7 +1,8 @@
 from datetime import UTC, datetime
+from typing import Annotated
 from uuid import uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StringConstraints
 
 
 class AnalysisResponse(BaseModel):
@@ -18,43 +19,62 @@ class AnalysisResponse(BaseModel):
 
 
 class EntryCreate(BaseModel):
-    """Model for creating a new journal entry (user input).
+    """Model for creating a new journal entry (user input)."""
 
-    TODO (Task 3): Add validation so that ``work``, ``struggle``, and ``intention``:
-      - reject empty strings and whitespace-only input
-      - strip surrounding whitespace
-      - have a max length of 256 characters
+    work: Annotated[
+        str,
+        StringConstraints(min_length=1, max_length=256, strip_whitespace=True),
+        Field(
+            description="What did you work on today?",
+            json_schema_extra={"example": "Studied FastAPI and built my first API endpoints"},
+        ),
+    ]
+    struggle: Annotated[
+        str,
+        StringConstraints(min_length=1, max_length=256, strip_whitespace=True),
+        Field(
+            description="What's one thing you struggled with today?",
+            json_schema_extra={"example": "Understanding async/await syntax and when to use it"},
+        ),
+    ]
+    intention: Annotated[
+        str,
+        StringConstraints(min_length=1, max_length=256, strip_whitespace=True),
+        Field(
+            description="What will you study/work on tomorrow?",
+            json_schema_extra={"example": "Practice PostgreSQL queries and database design"},
+        ),
+    ]
 
-    Hint: wrap the field type in ``Annotated[str, StringConstraints(...)]``.
-    See https://docs.pydantic.dev/latest/concepts/types/#constrained-types
-    """
 
-    work: str = Field(
-        max_length=256,
-        description="What did you work on today?",
-        json_schema_extra={"example": "Studied FastAPI and built my first API endpoints"},
-    )
-    struggle: str = Field(
-        max_length=256,
-        description="What's one thing you struggled with today?",
-        json_schema_extra={"example": "Understanding async/await syntax and when to use it"},
-    )
-    intention: str = Field(
-        max_length=256,
-        description="What will you study/work on tomorrow?",
-        json_schema_extra={"example": "Practice PostgreSQL queries and database design"},
-    )
-
-
-# TODO (Task 3): Define an ``EntryUpdate`` model for PATCH /entries/{entry_id}.
-#
-# Requirements:
-#   - All three fields (``work``, ``struggle``, ``intention``) must be optional.
-#   - Each field, when provided, must follow the same validation rules as
-#     ``EntryCreate`` (non-empty, whitespace-stripped, max 256 chars).
-#
-# Once defined, import ``EntryUpdate`` in ``api/routers/journal_router.py``
-# and use it as the type of the PATCH endpoint's request body.
+class EntryUpdate(BaseModel):
+    work: Annotated[
+        str,
+        StringConstraints(min_length=1, max_length=256, strip_whitespace=True),
+        Field(
+            default=None,
+            description="What did you work on today?",
+            json_schema_extra={"example": "Studied FastAPI and built my first API endpoints"},
+        ),
+    ]
+    struggle: Annotated[
+        str,
+        StringConstraints(min_length=1, max_length=256, strip_whitespace=True),
+        Field(
+            default=None,
+            description="What's one thing you struggled with today?",
+            json_schema_extra={"example": "Understanding async/await syntax and when to use it"},
+        ),
+    ]
+    intention: Annotated[
+        str,
+        StringConstraints(min_length=1, max_length=256, strip_whitespace=True),
+        Field(
+            default=None,
+            description="What will you study/work on tomorrow?",
+            json_schema_extra={"example": "Practice PostgreSQL queries and database design"},
+        ),
+    ]
 
 
 class Entry(BaseModel):

--- a/api/routers/journal_router.py
+++ b/api/routers/journal_router.py
@@ -59,14 +59,6 @@ async def update_entry(
     entry_update: EntryUpdate,
     entry_service: EntryService = Depends(get_entry_service),
 ):
-    """Update a journal entry.
-
-    TODO (Task 3): Replace ``entry_update: dict`` with ``entry_update: EntryUpdate``
-    (import it from ``api.models.entry``) so PATCH requests are validated the
-    same way POST requests are. Without this, PATCH happily accepts
-    empty strings and 300-character bodies — see ``TestUpdateEntry`` in
-    tests/test_api.py.
-    """
     result = await entry_service.update_entry(entry_id, dict(entry_update))
     if not result:
         raise HTTPException(status_code=404, detail="Entry not found")

--- a/api/routers/journal_router.py
+++ b/api/routers/journal_router.py
@@ -46,26 +46,6 @@ async def get_all_entries(entry_service: EntryService = Depends(get_entry_servic
 
 @router.get("/entries/{entry_id}")
 async def get_entry(entry_id: str, entry_service: EntryService = Depends(get_entry_service)):
-    """
-    TODO: Implement this endpoint to return a single journal entry by ID
-
-    Steps to implement:
-    1. Use entry_service.get_entry(entry_id) to fetch the entry
-    2. If entry is None, raise HTTPException with status_code=404
-    3. Return the entry directly (not wrapped in a dict)
-
-    Example response (status 200):
-    {
-        "id": "uuid-string",
-        "work": "...",
-        "struggle": "...",
-        "intention": "...",
-        "created_at": "...",
-        "updated_at": "..."
-    }
-
-    Hint: Check the update_entry endpoint for similar patterns
-    """
     result = await entry_service.get_entry(entry_id)
     if result is None:
         raise HTTPException(status_code=404, detail="Entry not found 404 error")

--- a/api/routers/journal_router.py
+++ b/api/routers/journal_router.py
@@ -72,25 +72,15 @@ async def update_entry(
     return result
 
 
-# TODO: Implement DELETE /entries/{entry_id} endpoint to remove a specific entry
 # Return 404 if entry not found
 @router.delete("/entries/{entry_id}")
 async def delete_entry(entry_id: str, entry_service: EntryService = Depends(get_entry_service)):
-    """
-    TODO: Implement this endpoint to delete a specific journal entry
-
-    Steps to implement:
-    1. Use entry_service.get_entry(entry_id) to check if entry exists
-    2. If entry is None, raise HTTPException with status_code=404
-    3. Use entry_service.delete_entry(entry_id) to delete the entry
-    4. Return a success response (status 200)
-
-    Example response (status 200):
-    {"detail": "Entry deleted successfully"}
-
-    Hint: Look at how the update_entry endpoint checks for existence
-    """
-    raise HTTPException(status_code=501, detail="Not implemented - complete this endpoint!")
+    result = await entry_service.get_entry(entry_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Entry not found")
+    await entry_service.delete_entry(entry_id)
+    return {"detail": "{entry_id} entry was deleted"}
+    # raise HTTPException(status_code=501, detail="Not implemented - complete this endpoint!")
 
 
 @router.delete("/entries")

--- a/api/routers/journal_router.py
+++ b/api/routers/journal_router.py
@@ -67,7 +67,7 @@ async def update_entry(
     empty strings and 300-character bodies — see ``TestUpdateEntry`` in
     tests/test_api.py.
     """
-    result = await entry_service.update_entry(entry_id, entry_update)
+    result = await entry_service.update_entry(entry_id, dict(entry_update))
     if not result:
         raise HTTPException(status_code=404, detail="Entry not found")
 

--- a/api/routers/journal_router.py
+++ b/api/routers/journal_router.py
@@ -3,7 +3,7 @@ from collections.abc import AsyncGenerator
 from fastapi import APIRouter, Depends, HTTPException
 
 from api.config import Settings, get_settings
-from api.models.entry import AnalysisResponse, Entry, EntryCreate
+from api.models.entry import AnalysisResponse, Entry, EntryCreate, EntryUpdate
 from api.repositories.postgres_repository import PostgresDB
 from api.services.entry_service import EntryService
 from api.services.llm_service import analyze_journal_entry
@@ -55,7 +55,9 @@ async def get_entry(entry_id: str, entry_service: EntryService = Depends(get_ent
 
 @router.patch("/entries/{entry_id}")
 async def update_entry(
-    entry_id: str, entry_update: dict, entry_service: EntryService = Depends(get_entry_service)
+    entry_id: str,
+    entry_update: EntryUpdate,
+    entry_service: EntryService = Depends(get_entry_service),
 ):
     """Update a journal entry.
 

--- a/api/routers/journal_router.py
+++ b/api/routers/journal_router.py
@@ -66,7 +66,11 @@ async def get_entry(entry_id: str, entry_service: EntryService = Depends(get_ent
 
     Hint: Check the update_entry endpoint for similar patterns
     """
-    raise HTTPException(status_code=501, detail="Not implemented - complete this endpoint!")
+    result = await entry_service.get_entry(entry_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Entry not found 404 error")
+    return result
+    # raise HTTPException(status_code=501, detail="Not implemented - complete this endpoint!")
 
 
 @router.patch("/entries/{entry_id}")

--- a/api/services/entry_service.py
+++ b/api/services/entry_service.py
@@ -47,9 +47,16 @@ class EntryService:
             logger.warning("Entry %s not found. Update aborted.", entry_id)
             return None
 
+        # this was added to not look at values with none
+        # we want to prevent fields that weren't updated being included in the updated_data dict
+        new_dict = {}
+        for key, value in updated_data.items():
+            if value is not None:
+                new_dict[key] = value
+
         updated_data = {
             **existing_entry,
-            **updated_data,
+            **new_dict,
             "id": entry_id,
             "updated_at": datetime.now(UTC),
         }

--- a/api/services/llm_service.py
+++ b/api/services/llm_service.py
@@ -12,6 +12,8 @@ Set OPENAI_API_KEY, and optionally OPENAI_BASE_URL and OPENAI_MODEL
 in your .env file. Settings are loaded by ``api.config.Settings``.
 """
 
+import json
+
 from openai import AsyncOpenAI
 
 from api.config import get_settings
@@ -62,7 +64,33 @@ async def analyze_journal_entry(
       4. Parse the assistant's JSON response with ``json.loads()``.
       5. Return a dict with ``entry_id``, ``sentiment``, ``summary``, ``topics``.
     """
-    raise NotImplementedError(
-        "Task 4: implement analyze_journal_entry using the openai SDK. "
-        "See tests/test_llm_service.py for the test contract."
+    if client is None:
+        client = _default_client()
+
+    # here it was important to have the system know what to do based on my user content
+    # it needed to know how I want the data returned and what the keys/values should be
+    response = await client.chat.completions.create(
+        model=get_settings().openai_model,
+        messages=[
+            {
+                "role": "system",
+                "content": "Return a dict in JSON format with ``entry_id``, ``sentiment``, ``summary``, ``topics``. The sentiment key should the value be either postive, negative or neutral. The summary key should the values summarize the entry_text. The topics key should have the value be a list of subjects or nouns mentioned in the entry_text",
+            },
+            {"role": "user", "content": entry_text},
+        ],
     )
+
+    # added this to prevent error if json.loads message content is empty
+    if response.choices[0].message.content is None:
+        raise ValueError()
+
+    valid_analyst_json = json.loads(response.choices[0].message.content)
+    # print(valid_analyst_json)
+
+    # we did this to fetch the output from valid_analyst_json and retrive the values in the dictionary
+    return {
+        "entry_id": entry_id,
+        "sentiment": valid_analyst_json["sentiment"],
+        "summary": valid_analyst_json["summary"],
+        "topics": valid_analyst_json["topics"],
+    }


### PR DESCRIPTION
# Background
When running the pytests all but 1 of them passed. We needed all 50 tests to pass.

```
FAILED tests/test_api.py::TestUpdateEntry::test_update_entry_success - AssertionError: assert None == 'Understanding async/await syntax and when to use it'
====================== 1 failed, 49 passed in 14.70s =========================
```

# Changes
I updated the `update_entry` function to not look at values set to `None`. We want to prevent fields that weren't updated being included in the updated_data dict.

# Validation and Tests
Running `uv run pytest` we can see all tests pass.

```
======================== 50 passed in 15.13s =============================
```

I also confirmed the curl API calls for each endpoint still work as well.