### PR TITLE
Fix Google Cloud CLI feature reference

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
 		// TODO: Add one of these cloud CLI tools based on your needs:
         // "ghcr.io/devcontainers/features/azure-cli:1": {},
         // "ghcr.io/devcontainers/features/aws-cli:1": {},
-        // "ghcr.io/devcontainers/features/gcloud:1": {}
+        // "ghcr.io/dhoeric/features/google-cloud-cli:1": {}
 	},
   
   "service": "devcontainer",


### PR DESCRIPTION
The Google Cloud CLI Dev Container feature reference was invalid. It has been replaced with a valid, commonly used feature.