### PR TITLE
Feature/ai analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+NOTES.md

--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 NOTES.md
+.devcontainer/devcontainer-lock.json

--- a/api/main.py
+++ b/api/main.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import FastAPI
 
 from api.routers.journal_router import router as journal_router
@@ -5,9 +7,19 @@ from api.routers.journal_router import router as journal_router
 # TODO (Task 1): Configure logging here.
 # Reference: https://docs.python.org/3/howto/logging.html
 # Steps:
-#   1. ``import logging`` at the top of this file.
-#   2. Call ``logging.basicConfig(level=logging.INFO, format="...")``.
+#   1. `import logging` at the top of this file.
+#   2. Call `logging.basicConfig(level=logging.INFO, format="...")`.
 #   3. Log an INFO message on startup (e.g. "Journal API starting up").
+
+# --- Task 1 solution ---
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+
+logger = logging.getLogger(__name__)
+logger.info("Journal API starting up")
+# --- end Task 1 solution ---
 
 app = FastAPI(
     title="Journal API",

--- a/api/models/entry.py
+++ b/api/models/entry.py
@@ -1,16 +1,34 @@
 from datetime import UTC, datetime
+from typing import Annotated
 from uuid import uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StringConstraints
+
+# ---------------------------------------------------------------
+# Task 3 — shared constrained type for journal text fields.
+#
+# Step 1: strip_whitespace=True  -> trims leading/trailing spaces first
+# Step 2: min_length=1           -> after stripping, "" and "   " fail
+# Step 3: max_length=256         -> rejects oversize input
+#
+# Order matters: Pydantic strips BEFORE checking min_length, so a
+# whitespace-only string collapses to "" and is rejected.
+# ---------------------------------------------------------------
+JournalText = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=256),
+]
 
 
 class AnalysisResponse(BaseModel):
     """Response model for journal entry analysis."""
 
     entry_id: str = Field(description="ID of the analyzed entry")
-    sentiment: str = Field(description="Sentiment: positive, negative, or neutral")
+    sentiment: str = Field(
+        description="Sentiment: positive, negative, or neutral")
     summary: str = Field(description="2 sentence summary of the entry")
-    topics: list[str] = Field(description="2-4 key topics mentioned in the entry")
+    topics: list[str] = Field(
+        description="2-4 key topics mentioned in the entry")
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
         description="Timestamp when the analysis was created",
@@ -18,54 +36,81 @@ class AnalysisResponse(BaseModel):
 
 
 class EntryCreate(BaseModel):
-    """Model for creating a new journal entry (user input).
+    """Model for creating a new journal entry (user input)."""
 
-    TODO (Task 3): Add validation so that ``work``, ``struggle``, and ``intention``:
-      - reject empty strings and whitespace-only input
-      - strip surrounding whitespace
-      - have a max length of 256 characters
+    # ---------------------------------------------------------------
+    # ORIGINAL STARTER TODO (kept for reference — Task 3, completed)
+    #
+    #   TODO (Task 3): Add validation so that work, struggle, intention:
+    #     - reject empty strings and whitespace-only input
+    #     - strip surrounding whitespace
+    #     - have a max length of 256 characters
+    #
+    #   Hint: wrap the field type in Annotated[str, StringConstraints(...)].
+    #
+    # Done: each field now uses JournalText (defined above), which carries
+    # all three rules. max_length was removed from Field() because the
+    # constraint now lives in the type.
+    # ---------------------------------------------------------------
+    work: JournalText = Field(
+        description="What did you work on today?",
+        json_schema_extra={
+            "example": "Studied FastAPI and built my first API endpoints"},
+    )
+    struggle: JournalText = Field(
+        description="What's one thing you struggled with today?",
+        json_schema_extra={
+            "example": "Understanding async/await syntax and when to use it"},
+    )
+    intention: JournalText = Field(
+        description="What will you study/work on tomorrow?",
+        json_schema_extra={
+            "example": "Practice PostgreSQL queries and database design"},
+    )
 
-    Hint: wrap the field type in ``Annotated[str, StringConstraints(...)]``.
-    See https://docs.pydantic.dev/latest/concepts/types/#constrained-types
+
+# ---------------------------------------------------------------
+# ORIGINAL STARTER TODO (kept for reference — Task 3, completed)
+#
+#   TODO (Task 3): Define an EntryUpdate model for PATCH /entries/{entry_id}.
+#
+#   Requirements:
+#     - All three fields (work, struggle, intention) must be optional.
+#     - Each field, when provided, must follow the same validation rules
+#       as EntryCreate (non-empty, whitespace-stripped, max 256 chars).
+#
+#   Once defined, import EntryUpdate in api/routers/journal_router.py
+#   and use it as the type of the PATCH endpoint's request body.
+# ---------------------------------------------------------------
+class EntryUpdate(BaseModel):
+    """Model for PATCH /entries/{entry_id} — partial update.
+
+    All fields optional (default None) so a caller can update just one.
+    When a value IS given, JournalText applies the same rules as
+    EntryCreate: stripped, non-empty, max 256 chars.
     """
 
-    work: str = Field(
-        max_length=256,
-        description="What did you work on today?",
-        json_schema_extra={"example": "Studied FastAPI and built my first API endpoints"},
-    )
-    struggle: str = Field(
-        max_length=256,
-        description="What's one thing you struggled with today?",
-        json_schema_extra={"example": "Understanding async/await syntax and when to use it"},
-    )
-    intention: str = Field(
-        max_length=256,
-        description="What will you study/work on tomorrow?",
-        json_schema_extra={"example": "Practice PostgreSQL queries and database design"},
-    )
-
-
-# TODO (Task 3): Define an ``EntryUpdate`` model for PATCH /entries/{entry_id}.
-#
-# Requirements:
-#   - All three fields (``work``, ``struggle``, ``intention``) must be optional.
-#   - Each field, when provided, must follow the same validation rules as
-#     ``EntryCreate`` (non-empty, whitespace-stripped, max 256 chars).
-#
-# Once defined, import ``EntryUpdate`` in ``api/routers/journal_router.py``
-# and use it as the type of the PATCH endpoint's request body.
+    # Step 1: JournalText | None  -> optional; validation only runs on a value
+    # Step 2: default=None        -> field can be omitted from the request body
+    work: JournalText | None = Field(
+        default=None, description="Updated work text.")
+    struggle: JournalText | None = Field(
+        default=None, description="Updated struggle text.")
+    intention: JournalText | None = Field(
+        default=None, description="Updated intention text.")
 
 
 class Entry(BaseModel):
     id: str = Field(
         default_factory=lambda: str(uuid4()), description="Unique identifier for the entry (UUID)."
     )
-    work: str = Field(..., max_length=256, description="What did you work on today?")
+    work: str = Field(..., max_length=256,
+                      description="What did you work on today?")
     struggle: str = Field(
         ..., max_length=256, description="What's one thing you struggled with today?"
     )
-    intention: str = Field(..., max_length=256, description="What will you study/work on tomorrow?")
+    intention: str = Field(..., max_length=256,
+                           description="What will you study/work on tomorrow?")
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
         description="Timestamp when the entry was created.",

--- a/api/routers/journal_router.py
+++ b/api/routers/journal_router.py
@@ -107,26 +107,45 @@ async def update_entry(
     return result
 
 
-# TODO: Implement DELETE /entries/{entry_id} endpoint to remove a specific entry
-# Return 404 if entry not found
+# DELETE /entries/{entry_id} — remove a specific entry. Returns 404 if not found.
+# Task 2b, completed.
 @router.delete("/entries/{entry_id}")
 async def delete_entry(entry_id: str, entry_service: EntryService = Depends(get_entry_service)):
-    """
-    TODO: Implement this endpoint to delete a specific journal entry
+    """Delete a single journal entry by ID."""
+    # ---------------------------------------------------------------
+    # ORIGINAL STARTER TODO (kept for reference — Task 2b, completed)
+    #
+    #   TODO: Implement this endpoint to delete a specific journal entry
+    #
+    #   Steps to implement:
+    #   1. Use entry_service.get_entry(entry_id) to check if entry exists
+    #   2. If entry is None, raise HTTPException with status_code=404
+    #   3. Use entry_service.delete_entry(entry_id) to delete the entry
+    #   4. Return a success response (status 200)
+    #
+    #   Example response (status 200):
+    #   {"detail": "Entry deleted successfully"}
+    #
+    #   Hint: Look at how the update_entry endpoint checks for existence
+    #
+    #   Was: raise HTTPException(status_code=501, detail="Not implemented...")
+    # ---------------------------------------------------------------
 
-    Steps to implement:
-    1. Use entry_service.get_entry(entry_id) to check if entry exists
-    2. If entry is None, raise HTTPException with status_code=404
-    3. Use entry_service.delete_entry(entry_id) to delete the entry
-    4. Return a success response (status 200)
+    # Step 1 — existence check. DELETE on a missing row succeeds silently
+    # in SQL (0 rows affected, no error), so we must check first or a
+    # bogus id would wrongly return 200.
+    entry = await entry_service.get_entry(entry_id)
 
-    Example response (status 200):
-    {"detail": "Entry deleted successfully"}
+    # Step 2 — translate "no row" into HTTP 404.
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Entry not found")
 
-    Hint: Look at how the update_entry endpoint checks for existence
-    """
-    raise HTTPException(
-        status_code=501, detail="Not implemented - complete this endpoint!")
+    # Step 3 — the actual delete. DELETE FROM entries WHERE id = $1.
+    await entry_service.delete_entry(entry_id)
+
+    # Step 4 — wrapped dict, NOT a bare return. Nothing to hand back after
+    # deletion, and the test asserts this exact shape.
+    return {"detail": "Entry deleted successfully"}
 
 
 @router.delete("/entries")

--- a/api/routers/journal_router.py
+++ b/api/routers/journal_router.py
@@ -3,7 +3,7 @@ from collections.abc import AsyncGenerator
 from fastapi import APIRouter, Depends, HTTPException
 
 from api.config import Settings, get_settings
-from api.models.entry import AnalysisResponse, Entry, EntryCreate
+from api.models.entry import AnalysisResponse, Entry, EntryCreate, EntryUpdate
 from api.repositories.postgres_repository import PostgresDB
 from api.services.entry_service import EntryService
 from api.services.llm_service import analyze_journal_entry
@@ -90,20 +90,41 @@ async def get_entry(entry_id: str, entry_service: EntryService = Depends(get_ent
 
 @router.patch("/entries/{entry_id}")
 async def update_entry(
-    entry_id: str, entry_update: dict, entry_service: EntryService = Depends(get_entry_service)
+    entry_id: str,
+    entry_update: EntryUpdate,
+    entry_service: EntryService = Depends(get_entry_service),
 ):
-    """Update a journal entry.
+    """Update a journal entry. Body validated by EntryUpdate (Task 3)."""
+    # ---------------------------------------------------------------
+    # ORIGINAL STARTER TODO (kept for reference — Task 3, completed)
+    #
+    #   TODO (Task 3): Replace entry_update: dict with entry_update: EntryUpdate
+    #   (import it from api.models.entry) so PATCH requests are validated the
+    #   same way POST requests are. Without this, PATCH happily accepts
+    #   empty strings and 300-character bodies — see TestUpdateEntry in
+    #   tests/test_api.py.
+    #
+    #   Done: param is now EntryUpdate. FastAPI validates it before this
+    #   function body runs, so bad input returns 422 automatically —
+    #   no manual validation code needed here.
+    # ---------------------------------------------------------------
 
-    TODO (Task 3): Replace ``entry_update: dict`` with ``entry_update: EntryUpdate``
-    (import it from ``api.models.entry``) so PATCH requests are validated the
-    same way POST requests are. Without this, PATCH happily accepts
-    empty strings and 300-character bodies — see ``TestUpdateEntry`` in
-    tests/test_api.py.
-    """
-    result = await entry_service.update_entry(entry_id, entry_update)
+    # Step 1 — convert the validated model back into a dict for the service.
+    #   entry_update arrives as an EntryUpdate instance (FastAPI built it).
+    #   model_dump() turns it back into a plain dict the service expects.
+    #   exclude_unset=True: include ONLY the fields the caller actually sent,
+    #   so omitted fields keep their existing values (true partial update).
+    #   Without it, unsent fields become None and would wipe existing data.
+    result = await entry_service.update_entry(
+        entry_id, entry_update.model_dump(exclude_unset=True)
+    )
+
+    # Step 2 — existence check. The service returns a falsy value when no
+    #   row matched that id → translate that into HTTP 404.
     if not result:
         raise HTTPException(status_code=404, detail="Entry not found")
 
+    # Step 3 — return the updated entry (the service hands back the new row).
     return result
 
 

--- a/api/routers/journal_router.py
+++ b/api/routers/journal_router.py
@@ -46,27 +46,46 @@ async def get_all_entries(entry_service: EntryService = Depends(get_entry_servic
 
 @router.get("/entries/{entry_id}")
 async def get_entry(entry_id: str, entry_service: EntryService = Depends(get_entry_service)):
+    """Get a single journal entry by ID.
+
+    Returns the entry as a flat JSON object, or 404 if no entry has that id.
     """
-    TODO: Implement this endpoint to return a single journal entry by ID
+    # ---------------------------------------------------------------
+    # ORIGINAL STARTER TODO (kept for reference — Task 2a, completed)
+    #
+    #   TODO: Implement this endpoint to return a single journal entry by ID
+    #
+    #   Steps to implement:
+    #   1. Use entry_service.get_entry(entry_id) to fetch the entry
+    #   2. If entry is None, raise HTTPException with status_code=404
+    #   3. Return the entry directly (not wrapped in a dict)
+    #
+    #   Example response (status 200):
+    #   {
+    #       "id": "uuid-string",
+    #       "work": "...",
+    #       "struggle": "...",
+    #       "intention": "...",
+    #       "created_at": "...",
+    #       "updated_at": "..."
+    #   }
+    #
+    #   Hint: Check the update_entry endpoint for similar patterns
+    #
+    #   Was: raise HTTPException(status_code=501, detail="Not implemented...")
+    # ---------------------------------------------------------------
 
-    Steps to implement:
-    1. Use entry_service.get_entry(entry_id) to fetch the entry
-    2. If entry is None, raise HTTPException with status_code=404
-    3. Return the entry directly (not wrapped in a dict)
+    # Step 1 — delegate to the service layer. Returns dict | None.
+    entry = await entry_service.get_entry(entry_id)
 
-    Example response (status 200):
-    {
-        "id": "uuid-string",
-        "work": "...",
-        "struggle": "...",
-        "intention": "...",
-        "created_at": "...",
-        "updated_at": "..."
-    }
+    # Step 2 — the DB signals "no row" with None. HTTP signals it with 404.
+    # This router is the only layer that knows how to speak HTTP.
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Entry not found")
 
-    Hint: Check the update_entry endpoint for similar patterns
-    """
-    raise HTTPException(status_code=501, detail="Not implemented - complete this endpoint!")
+    # Step 3 — return bare, NOT wrapped. Tests assert entry["id"], not
+    # result["entry"]["id"]. Wrapping is the most common way to fail here.
+    return entry
 
 
 @router.patch("/entries/{entry_id}")
@@ -106,7 +125,8 @@ async def delete_entry(entry_id: str, entry_service: EntryService = Depends(get_
 
     Hint: Look at how the update_entry endpoint checks for existence
     """
-    raise HTTPException(status_code=501, detail="Not implemented - complete this endpoint!")
+    raise HTTPException(
+        status_code=501, detail="Not implemented - complete this endpoint!")
 
 
 @router.delete("/entries")
@@ -139,4 +159,5 @@ async def analyze_entry(entry_id: str, entry_service: EntryService = Depends(get
             detail="LLM analysis not yet implemented - see api/services/llm_service.py",
         ) from e
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Analysis failed: {e!s}") from e
+        raise HTTPException(
+            status_code=500, detail=f"Analysis failed: {e!s}") from e

--- a/api/services/llm_service.py
+++ b/api/services/llm_service.py
@@ -12,6 +12,8 @@ Set OPENAI_API_KEY, and optionally OPENAI_BASE_URL and OPENAI_MODEL
 in your .env file. Settings are loaded by ``api.config.Settings``.
 """
 
+import json
+
 from openai import AsyncOpenAI
 
 from api.config import get_settings
@@ -52,17 +54,74 @@ async def analyze_journal_entry(
                 "summary":   str,
                 "topics":    list[str],
             }
-
-    TODO (Task 4):
-      1. If ``client is None``, call ``_default_client()`` to construct one.
-      2. Build a messages list that includes ``entry_text`` somewhere
-         (the unit tests check that the entry text reaches the LLM).
-      3. Call ``client.chat.completions.create(...)`` with a model name
-         (use ``get_settings().openai_model`` — defaults to "gpt-4o-mini").
-      4. Parse the assistant's JSON response with ``json.loads()``.
-      5. Return a dict with ``entry_id``, ``sentiment``, ``summary``, ``topics``.
     """
-    raise NotImplementedError(
-        "Task 4: implement analyze_journal_entry using the openai SDK. "
-        "See tests/test_llm_service.py for the test contract."
+    # ---------------------------------------------------------------
+    # ORIGINAL STARTER TODO (kept for reference — Task 4, completed)
+    #
+    #   1. If client is None, call _default_client() to construct one.
+    #   2. Build a messages list that includes entry_text somewhere
+    #      (the unit tests check that the entry text reaches the LLM).
+    #   3. Call client.chat.completions.create(...) with a model name
+    #      (use get_settings().openai_model — defaults to "gpt-4o-mini").
+    #   4. Parse the assistant's JSON response with json.loads().
+    #   5. Return a dict with entry_id, sentiment, summary, topics.
+    #
+    #   Was: raise NotImplementedError(...)
+    # ---------------------------------------------------------------
+
+    # Step 1 — pick the client.
+    #   Tests inject a MockAsyncOpenAI (client is not None), so this branch
+    #   is skipped and no real network call is ever made in the test suite.
+    #   In production the router calls us with no client, so we build the
+    #   real one lazily here — only when actually needed.
+    if client is None:
+        client = _default_client()
+
+    settings = get_settings()
+
+    # Step 2 — build the messages list.
+    #   system message: pins the model to a strict JSON contract so the
+    #     response is machine-parseable (no markdown, no prose).
+    #   user message: carries entry_text. The test asserts that "FastAPI"
+    #     (part of the sample entry) reaches the LLM, so entry_text MUST
+    #     appear in a message's content — this is where it goes.
+    system_prompt = (
+        "You are a journaling assistant. Analyze the entry and respond with "
+        "ONLY a JSON object, no markdown, no prose, with exactly these keys: "
+        '"sentiment" (one of "positive", "negative", "neutral"), '
+        '"summary" (a 2-sentence string), '
+        '"topics" (a list of 2-4 short strings).'
     )
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": entry_text},
+    ]
+
+    # Step 3 — call the LLM.
+    #   model comes from settings (defaults to "gpt-4o-mini").
+    #   response_format nudges compatible providers (OpenAI, GitHub Models)
+    #   to emit valid JSON. It's harmless where unsupported because the
+    #   prompt already demands JSON. The mock ignores kwargs entirely.
+    response = await client.chat.completions.create(
+        model=settings.openai_model,
+        messages=messages,
+        response_format={"type": "json_object"},
+    )
+
+    # Step 4 — parse the assistant's reply.
+    #   The model's text lives at choices[0].message.content. Fall back to
+    #   "{}" if it's None so json.loads never crashes on a null response.
+    raw = response.choices[0].message.content or "{}"
+    parsed = json.loads(raw)
+
+    # Step 5 — assemble the result dict.
+    #   entry_id is injected HERE, not requested from the model — the LLM
+    #   never sees it and never returns it. AnalysisResponse (checked in the
+    #   test) requires entry_id, so we add it ourselves alongside the three
+    #   fields the model produced.
+    return {
+        "entry_id": entry_id,
+        "sentiment": parsed["sentiment"],
+        "summary": parsed["summary"],
+        "topics": parsed["topics"],
+    }


### PR DESCRIPTION
Task 4 — AI-Powered Entry Analysis

api/services/llm_service.py:
- Uses injected client if given (mock in tests), else builds real one via _default_client()
- Messages: system prompt pins strict JSON output, user message carries entry_text
- Calls chat.completions.create with settings.openai_model + json_object response_format
- Parses response, injects entry_id (LLM never sees it), returns dict for AnalysisResponse

Testing:
- test_llm_service.py 3 passed (mocked client, no network)
- Full suite: 50 passed
- ruff + pyright clean