### PR TITLE
Add hands-on checks to the capstone documentation

### DIFF
--- a/docs/04-get-entry.md
+++ b/docs/04-get-entry.md
@@ -64,7 +64,18 @@ implementation exercise.
 
 4. Save your changes.
 
-## 3. Run the Checks
+## 3. Try It Yourself
+
+1. [Start the API](03-run-the-api.md#3-start-the-api).
+2. Open <http://localhost:8000/docs>.
+3. Use **POST `/entries`** to create a made-up entry. Expect **201** and copy
+   `entry.id` from the response.
+4. Open **GET `/entries/{entry_id}`**, click **Try it out**, enter that ID,
+   and click **Execute**. Expect **200** with the same ID and text.
+5. Try a nonexistent UUID, such as `00000000-0000-0000-0000-000000000000`.
+   Expect **404** with a `detail` message.
+
+## 4. Run the Checks
 
 1. Run the acceptance tests for this endpoint:
 
@@ -105,7 +116,7 @@ implementation exercise.
    CI also runs the starter tests and all exercises up to the task selected by
    your pull request label. Later, unfinished exercises are not included.
 
-## 4. Review and Submit Your Work
+## 5. Review and Submit Your Work
 
 1. Review your code changes:
 

--- a/docs/05-delete-entry.md
+++ b/docs/05-delete-entry.md
@@ -60,7 +60,20 @@ can remove one journal entry.
 
 4. Save your changes.
 
-## 3. Run the Checks
+## 3. Try It Yourself
+
+1. [Start the API](03-run-the-api.md#3-start-the-api).
+2. Open <http://localhost:8000/docs>.
+3. Use **POST `/entries`** to create a disposable, made-up entry. Expect **201**
+   and copy `entry.id`.
+4. Use **DELETE `/entries/{entry_id}`** with that ID. Expect **200** with
+   `{"detail": "Entry deleted successfully"}`.
+5. Use **GET `/entries/{entry_id}`** with the same ID. Expect **404**.
+6. Delete the same ID again. Expect **404**.
+
+Do not use **DELETE `/entries`**: it deletes every entry.
+
+## 4. Run the Checks
 
 1. Run the DELETE endpoint tests:
 
@@ -88,7 +101,7 @@ can remove one journal entry.
    uv run pyright
    ```
 
-## 4. Review and Submit Your Work
+## 5. Review and Submit Your Work
 
 1. Review your changes:
 

--- a/docs/06-input-validation.md
+++ b/docs/06-input-validation.md
@@ -159,7 +159,39 @@ happens next.
 If tests do not appear or a breakpoint is not reached, use the
 [debugger troubleshooting guide](reference/troubleshooting.md#tests-do-not-appear-or-breakpoints-are-not-hit).
 
-## 5. Run the Checks
+## 5. Try It Yourself
+
+1. [Start the API](03-run-the-api.md#3-start-the-api).
+2. Open or refresh <http://localhost:8000/docs>.
+3. Send **POST `/entries`** with this body:
+
+   ```json
+   {
+     "work": "   ",
+     "struggle": "Understanding partial updates",
+     "intention": "Practice input validation"
+   }
+   ```
+
+   Expect **422** with an error identifying `work`.
+
+4. Change `work` to `"Practiced API requests"` and POST again. Expect **201**
+   and copy `entry.id`.
+5. Send **PATCH `/entries/{entry_id}`** with that ID and only this body:
+
+   ```json
+   {"work": "  Updated description  "}
+   ```
+
+   Expect **200** with `work` trimmed to `"Updated description"`.
+
+6. GET the entry. Confirm `struggle`, `intention`, `id`, and `created_at`
+   still match the creation response.
+7. Try PATCH with `{"work": null}`, then `{"work": "   "}`. Expect **422**
+   for each. GET again to confirm nothing changed.
+8. Try PATCH with `{}`. Expect **200** with all three text fields unchanged.
+
+## 6. Run the Checks
 
 1. Run the model and endpoint tests for this task:
 
@@ -192,7 +224,7 @@ If tests do not appear or a breakpoint is not reached, use the
    uv run pyright
    ```
 
-## 6. Review and Submit Your Work
+## 7. Review and Submit Your Work
 
 1. Review your changes:
 

--- a/docs/09-ai-analysis.md
+++ b/docs/09-ai-analysis.md
@@ -278,7 +278,17 @@ Write these steps inside `try`, after the request and before `finally`.
    run or the live verification below. Implementation tests are expected to
    fail while the starter still raises `NotImplementedError`.
 
-## 4. Run the Checks
+## 4. Try It Yourself
+
+1. [Start the API](03-run-the-api.md#3-start-the-api). Restart it if you changed `.env`.
+2. Open <http://localhost:8000/docs>.
+3. Use **POST `/entries`** to create a made-up entry. Expect **201** and copy `entry.id`.
+4. Use **POST `/entries/{entry_id}/analyze`** with that ID. This sends the text
+   to your AI provider and may incur charges; execute it once.
+5. Expect **200** with the matching `entry_id`, `sentiment`, `summary`, `topics`,
+   and `created_at`. Generated wording can vary.
+
+## 5. Run the Checks
 
 1. Run the mocked service tests:
 
@@ -321,7 +331,7 @@ Write these steps inside `try`, after the request and before `finally`.
    uv run pyright
    ```
 
-## 5. Review and Submit Your Work
+## 6. Review and Submit Your Work
 
 1. Review your changes:
 

--- a/docs/10-finish.md
+++ b/docs/10-finish.md
@@ -27,7 +27,67 @@ In this chapter, you will confirm that the complete project works on your merged
    git pull origin main
    ```
 
-## 2. Run the Full Test Suite
+## 2. Try the Complete Workflow
+
+1. [Start the API](03-run-the-api.md#3-start-the-api).
+2. Open a second terminal in the development container. Run all commands below
+   there. `curl -i` shows the HTTP status, headers, and response body.
+3. Create a disposable entry using this made-up content:
+
+   ```bash
+   curl -i -X POST http://localhost:8000/entries \
+     -H 'Content-Type: application/json' \
+     -d '{"work":"Practiced API requests","struggle":"Reading HTTP responses","intention":"Review the complete workflow"}'
+   ```
+
+   Expect **201**.
+
+4. Replace `PASTE_ID_HERE` with `entry.id` from the response:
+
+   ```bash
+   ENTRY_ID='PASTE_ID_HERE'
+   ```
+
+5. Retrieve the entry:
+
+   ```bash
+   curl -i "http://localhost:8000/entries/$ENTRY_ID"
+   ```
+
+   Expect **200** with the same ID and text.
+
+6. Update `work`, then retrieve the entry:
+
+   ```bash
+   curl -i -X PATCH "http://localhost:8000/entries/$ENTRY_ID" \
+     -H 'Content-Type: application/json' \
+     -d '{"work":"Completed the manual API workflow"}'
+   curl -i "http://localhost:8000/entries/$ENTRY_ID"
+   ```
+
+   Expect **200** for both. Only `work` and `updated_at` should change.
+
+7. Analyze the entry once. This sends its text to your AI provider and may incur charges:
+
+   ```bash
+   curl -i -X POST "http://localhost:8000/entries/$ENTRY_ID/analyze"
+   ```
+
+   Expect **200** with the matching `entry_id`, `sentiment`, `summary`, `topics`,
+   and `created_at`.
+
+8. Delete the entry, GET it, then delete it again:
+
+   ```bash
+   curl -i -X DELETE "http://localhost:8000/entries/$ENTRY_ID"
+   curl -i "http://localhost:8000/entries/$ENTRY_ID"
+   curl -i -X DELETE "http://localhost:8000/entries/$ENTRY_ID"
+   ```
+
+   Expect **200**, **404**, and **404**, respectively.
+   Do not use **DELETE `/entries`**: it deletes every entry.
+
+## 3. Run the Full Test Suite
 
 1. Run all tests:
 
@@ -39,7 +99,7 @@ In this chapter, you will confirm that the complete project works on your merged
 
 2. Read the test summary. Resolve any failures before marking the capstone complete.
 
-## 3. Run Code Quality
+## 4. Run Code Quality
 
 1. Run Ruff:
 
@@ -59,7 +119,7 @@ In this chapter, you will confirm that the complete project works on your merged
    uv run pyright
    ```
 
-## 4. Confirm the Live AI Integration
+## 5. Confirm the Live AI Integration
 
 1. With your provider settings still in `.env`, run:
 
@@ -70,7 +130,7 @@ In this chapter, you will confirm that the complete project works on your merged
 2. Confirm that the output includes `Validated AnalysisResponse:` and the
    bundled sample's analysis.
 
-## 5. Confirm the Cloud CLI
+## 6. Confirm the Cloud CLI
 
 Run only the step for the CLI you installed:
 
@@ -95,7 +155,7 @@ Run only the step for the CLI you installed:
 Your selected command should print version information. No cloud login or
 deployment is required.
 
-## 6. Update Your CI Badge
+## 7. Update Your CI Badge
 
 The CI badge in `README.md` currently reports the upstream starter's status.
 Point it to your fork so visitors see the status of your own `main` branch.
@@ -144,7 +204,7 @@ Point it to your fork so visitors see the status of your own `main` branch.
    git pull origin main
    ```
 
-## 7. Verify the Capstone on GitHub
+## 8. Verify the Capstone on GitHub
 
 1. After merging all work into your fork's `main`, open your repository on GitHub.
 2. Go to **Actions → Verify capstone → Run workflow**.
@@ -160,6 +220,7 @@ Point it to your fork so visitors see the status of your own `main` branch.
 - The input-validation pull request explains the partial update observed in the debugger.
 - The logging pull request includes a log sample and your observations.
 - The AI analysis pull request includes successful live verification.
+- The manual create, retrieve, update, analyze, and delete workflow succeeds on the merged code.
 - The full test suite passes.
 - Ruff and Pyright pass.
 - **Verify capstone** succeeds for the current `main` commit before submitting

--- a/docs/reference/testing-and-ci.md
+++ b/docs/reference/testing-and-ci.md
@@ -55,7 +55,7 @@ The separate manual **Verify capstone** workflow
 commit with the entire suite, Ruff, and Pyright, without task-label filtering.
 An unfinished starter is expected to fail this workflow.
 
-Follow [Finish the Capstone](../10-finish.md#7-verify-the-capstone-on-github) to run
+Follow [Finish the Capstone](../10-finish.md#8-verify-the-capstone-on-github) to run
 it before submitting verification in the Learn to Cloud app. Rerun it if `main`
 changes before submission. This offline check does not replace live AI or local
 cloud CLI verification.


### PR DESCRIPTION
## Summary
Bring the documentation updates from the learner fork into the upstream starter without including exercise implementations or fork-specific configuration.

- Add Try It Yourself walkthroughs for GET, DELETE, input validation, and AI analysis.
- Add an end-to-end manual workflow to the finish chapter, including expected responses and safety notes.
- Renumber sections and update the capstone verification link.

## Validation
- All six documents match the original documentation commit (7be1954).
- git diff --check passed.
- Confirmed the updated verification link points to section 8.
- Application tests not run: documentation-only changes.