### PR TITLE
Add a cloud CLI to devcontainer

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,5 +1,10 @@
 {
   "features": {
+    "ghcr.io/devcontainers/features/aws-cli:1": {
+      "version": "1.1.4",
+      "resolved": "ghcr.io/devcontainers/features/aws-cli@sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef",
+      "integrity": "sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef"
+    },
     "ghcr.io/va-h/devcontainers-features/uv": {
       "version": "1.1.4",
       "resolved": "ghcr.io/va-h/devcontainers-features/uv@sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 		"ghcr.io/va-h/devcontainers-features/uv": {},
 		// TODO: Add one of these cloud CLI tools based on your needs:
         // "ghcr.io/devcontainers/features/azure-cli:1": {},
-        // "ghcr.io/devcontainers/features/aws-cli:1": {},
+        "ghcr.io/devcontainers/features/aws-cli:1": {},
         // "ghcr.io/dhoeric/features/google-cloud-cli:1": {}
 	},
   


### PR DESCRIPTION
This pull request adds a cloud CLI to the development container. The cloud CLI is installed as a feature in the development container configuration file. This change allows developers to use the cloud CLI in the development container without having to install it manually.